### PR TITLE
fix for critical error during build task (specifically the styles task)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jshint-stylish": "^1.0.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
-    "watchify": "^2.1.1"
+    "watchify": "^3.7.0"
   },
   "browser": {
     "jquery": "./app/src/vendor/jquery/dist/jquery.js",


### PR DESCRIPTION
fix for critical error during build task (specifically the styles task) that does not allow build to continue

tested on node version 6.3.1 & npm version 3.10.5